### PR TITLE
feat: allow hashable types to be used as direct hits

### DIFF
--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,4 +1,4 @@
-from typing import Generic, List, Optional, Sequence, TypeVar, Union
+from typing import Optional, Sequence, Union
 from unittest.mock import Mock
 
 import pytest
@@ -125,32 +125,3 @@ def test_unlikely_processor():
 
     with pytest.raises(ValueError, match="Processors must be callable"):
         set_processors({int: 1})
-
-
-def test_no_generics():
-    T = TypeVar("T")
-
-    class G(Generic[T]):
-        ...
-
-    # parametrized generics not yet supported
-    with pytest.raises(TypeError, match="cannot be used as a processor"):
-
-        @processor
-        def _(x: List[int]):
-            ...
-
-    with pytest.raises(TypeError, match="cannot be used as a processor"):
-
-        @processor
-        def _(x: G[int]):
-            ...
-
-    # but ok without params
-    @processor
-    def _(x: List):
-        ...
-
-    @processor
-    def _(x: G):
-        ...

--- a/tests/test_type_support.py
+++ b/tests/test_type_support.py
@@ -1,0 +1,71 @@
+from collections import ChainMap
+from typing import (
+    Callable,
+    Generic,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    NewType,
+    Sequence,
+    Set,
+    TypeVar,
+)
+from unittest.mock import Mock
+
+import pytest
+
+from in_n_out import Store
+
+T = TypeVar("T")
+
+
+class G(Generic[T]):
+    ...
+
+
+nt = NewType("nt", int)
+NON_SUBCLASSABLE_TYPES = ["hi", nt, List[nt], T, Callable[[int], str], G[int]]
+SUBCLASS_PAIRS = [
+    (list, Sequence),
+    (tuple, Sequence),
+    (dict, Mapping),
+    (set, Set),
+    (list, Iterable),
+    (ChainMap, MutableMapping),
+]
+
+
+@pytest.mark.parametrize("type_", NON_SUBCLASSABLE_TYPES)
+@pytest.mark.parametrize("mode", ["provider", "processor"])
+def test_non_standard_types(test_store: Store, type_, mode) -> None:
+    mock = Mock(return_value=1)
+    if mode == "provider":
+        test_store.register_provider(type_, mock)
+        assert test_store.provide(type_) == 1
+        mock.assert_called_once()
+    else:
+        test_store.register_processor(type_, mock)
+        test_store.process(type_, 2)
+        mock.assert_called_once_with(2)
+
+
+def test_provider_type_error(test_store: Store) -> None:
+    with pytest.raises(TypeError, match="cannot be used as a provider hint"):
+        test_store.register_provider(set(), lambda: 1)
+    with pytest.raises(TypeError, match="cannot be used as a processor hint"):
+        test_store.register_processor(set(), lambda x: None)
+
+
+@pytest.mark.parametrize("sub, sup", SUBCLASS_PAIRS)
+@pytest.mark.parametrize("mode", ["provider", "processor"])
+def test_subclass_pairs(test_store: Store, sub, sup, mode) -> None:
+    mock = Mock(return_value=1)
+    if mode == "provider":
+        test_store.register_provider(sup, mock)
+        assert test_store.provide(sub) == 1
+        mock.assert_called_once()
+    else:
+        test_store.register_processor(sup, mock)
+        test_store.process(sub, 2)
+        mock.assert_called_once_with(2)


### PR DESCRIPTION
allows things like `NewType()` and parametrized generics to be used directly (without checking subclass)