### PR TITLE
feat: split decorator into 2

### DIFF
--- a/src/in_n_out/__init__.py
+++ b/src/in_n_out/__init__.py
@@ -9,7 +9,7 @@ except PackageNotFoundError:  # pragma: no cover
 __author__ = "Talley Lambert"
 __email__ = "talley.lambert@gmail.com"
 
-from ._inject import inject_dependencies
+from ._inject import inject_dependencies, process_output
 from ._processors import iter_processors, processor, set_processors
 from ._providers import iter_providers, provider, set_providers
 from ._store import Store
@@ -26,6 +26,7 @@ __all__ = [
     "iter_providers",
     "inject_dependencies",
     "processor",
+    "process_output",
     "provider",
     "resolve_single_type_hints",
     "resolve_type_hints",

--- a/src/in_n_out/_inject.py
+++ b/src/in_n_out/_inject.py
@@ -24,7 +24,7 @@ def inject_dependencies(
     store: Union[str, Store, None] = None,
     on_unresolved_required_args: OptRaiseWarnReturnIgnore = None,
     on_unannotated_required_args: OptRaiseWarnReturnIgnore = None,
-) -> Callable[P, R]:
+) -> Callable[..., R]:
     ...
 
 
@@ -36,7 +36,7 @@ def inject_dependencies(
     store: Union[str, Store, None] = None,
     on_unresolved_required_args: OptRaiseWarnReturnIgnore = None,
     on_unannotated_required_args: OptRaiseWarnReturnIgnore = None,
-) -> Callable[[Callable[P, R]], Callable[P, R]]:
+) -> Callable[[Callable[..., R]], Callable[..., R]]:
     ...
 
 
@@ -47,7 +47,7 @@ def inject_dependencies(
     store: Union[str, Store, None] = None,
     on_unresolved_required_args: OptRaiseWarnReturnIgnore = None,
     on_unannotated_required_args: OptRaiseWarnReturnIgnore = None,
-) -> Union[Callable[P, R], Callable[[Callable[P, R]], Callable[P, R]]]:
+) -> Union[Callable[..., R], Callable[[Callable[..., R]], Callable[..., R]]]:
     """Decorator returns func that can access/process objects based on type hints.
 
     This is form of dependency injection, and result processing.  It does 2 things:


### PR DESCRIPTION
With this, `inject_dependencies` now does exactly that by default, _to the exclusion of processors_.  One can inject processor handling with

```python
@process_output
def f() -> int: ...

# or

@inject_dependencies(process_output=True):
def f() -> int: ...
```