### PR TITLE
test: add generator test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,55 +105,89 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-  build:
-    name: Build wheels on ${{ matrix.os }}
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+  # SKIPPING CYTHON WHEELS UNTIL # https://github.com/cython/cython/issues/4888
+  # build:
+  #   name: Build wheels on ${{ matrix.os }}
+  #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.9"
+
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v2.8.0
+
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  #     - name: Build sdist
+  #       if: matrix.os == 'ubuntu-20.04'
+  #       run: |
+  #         python -m pip install build
+  #         python -m build --sdist
+
+  #     - uses: actions/upload-artifact@v3
+  #       if: matrix.os == 'ubuntu-20.04'
+  #       with:
+  #         path: dist/*.tar.gz
+
+  # upload_pypi:
+  #   name: Deploy
+  #   needs: [check-manifest, build]
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: artifact
+  #         path: dist
+
+  #     - uses: pypa/gh-action-pypi-publish@v1.5.0
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.pypi_token }}
+
+  #     - uses: softprops/action-gh-release@v1
+  #       with:
+  #         generate_release_notes: true
+
+
+  deploy:
+    name: Deploy
+    needs: test
+    if: "success() && startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.x"
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.0
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
-      - name: Build sdist
-        if: matrix.os == 'ubuntu-20.04'
+      - name: install
         run: |
-          python -m pip install build
-          python -m build --sdist
-
-      - uses: actions/upload-artifact@v3
-        if: matrix.os == 'ubuntu-20.04'
-        with:
-          path: dist/*.tar.gz
-
-  upload_pypi:
-    name: Deploy
-    needs: [check-manifest, build]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
+          git tag
+          pip install -U pip
+          pip install -U build twine
+          python -m build
+          twine check dist/*
+          ls -lh dist
+      - name: Build and publish
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
       - uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
         platform: ["ubuntu-latest"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
           python -m build
           twine check dist/*
           ls -lh dist
+        env:
+          SKIP_CYTHON: 1
+
       - name: Build and publish
         run: twine upload dist/*
         env:

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -867,6 +867,11 @@ class Store:
         """
 
         def _deco(func: Callable[P, R]) -> Callable[P, R]:
+            if isgeneratorfunction(func):
+                raise TypeError(
+                    "Cannot decorate a generator function with inject_processors"
+                )
+
             nonlocal type_hint
             if type_hint is None:
                 annotations = getattr(func, "__annotations__", {})

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,5 +1,6 @@
 from contextlib import nullcontext
-from typing import ContextManager, Optional
+from inspect import isgeneratorfunction
+from typing import ContextManager, Generator, Optional
 from unittest.mock import Mock
 
 import pytest
@@ -216,3 +217,18 @@ def test_inject_instance_into_unbound_method():
     foo = Foo()
     with register(providers={Foo: lambda: foo}):
         assert inject(Foo.method)() == foo
+
+
+def test_generators():
+    def generator_func() -> Generator:
+        yield 1
+        yield 2
+        yield 3
+
+    assert isgeneratorfunction(generator_func)
+    assert list(generator_func()) == [1, 2, 3]
+
+    injected = inject(generator_func)
+
+    assert isgeneratorfunction(injected)
+    assert list(injected()) == [1, 2, 3]

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -234,3 +234,6 @@ def test_generators():
 
     assert isgeneratorfunction(injected)
     assert list(injected()) == [1, 2, 3]
+
+    with pytest.raises(TypeError, match="generator function"):
+        inject(generator_func, processors=True)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from in_n_out import Store, inject, inject_processors, register
+from in_n_out import Store, _compiled, inject, inject_processors, register
 
 
 def test_injection():
@@ -219,6 +219,8 @@ def test_inject_instance_into_unbound_method():
         assert inject(Foo.method)() == foo
 
 
+# https://github.com/cython/cython/issues/4888
+@pytest.mark.xfail(bool(_compiled), reason="Cython doesn't support this", strict=True)
 def test_generators():
     def generator_func() -> Generator:
         yield 1


### PR DESCRIPTION
Cythonization of a generator function does not preserve the `__code__.co_flags` required to determine if that function is a generator function.  https://github.com/cython/cython/issues/4888

That breaks a lot of use cases (e.g. for napari), so for now, this PR falls back to shipping pure python (uncompiled) wheels