### PR TITLE
feat: add on_unresolved_required_args="ignore" to inject()

### DIFF
--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -201,7 +201,7 @@ class Store:
         self._providers: List[_RegisteredCallback] = []
         self._processors: List[_RegisteredCallback] = []
         self._namespace: Union[Namespace, Callable[[], Namespace], None] = None
-        self.on_unresolved_required_args: RaiseWarnReturnIgnore = "raise"
+        self.on_unresolved_required_args: RaiseWarnReturnIgnore = "warn"
         self.on_unannotated_required_args: RaiseWarnReturnIgnore = "warn"
         self.guess_self: bool = True
 
@@ -646,13 +646,13 @@ class Store:
         on_unresolved_required_args : RaiseWarnReturnIgnore
             What to do when a required parameter (one without a default) is encountered
             with an unresolvable type annotation.
-            Must be one of the following (by default 'raise'):
+            Must be one of the following (by default 'warn'):
 
                 - 'raise': immediately raise an exception
                 - 'warn': warn and return the original function
                 - 'return': return the original function without warning
-                - 'ignore': currently an alias for `return`, but will be used in
-                the future to allow the decorator to proceed.
+                - 'ignore': continue decorating without warning (at call time, this
+                    function will fail without additional arguments).
 
         on_unannotated_required_args : RaiseWarnReturnIgnore
             What to do when a required parameter (one without a default) is encountered

--- a/src/in_n_out/_type_resolution.py
+++ b/src/in_n_out/_type_resolution.py
@@ -277,7 +277,7 @@ def _resolve_sig_or_inform(
 
     for param in sig.parameters.values():
         if param.default is not param.empty:
-            continue
+            continue  # pragma: no cover
         if isinstance(param.annotation, (str, ForwardRef)):
             errmsg = (
                 f"Could not resolve type hint for required parameter {param.name!r}"

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -111,11 +111,11 @@ def test_injection_without_args():
 modes = ["raise", "warn", "return", "ignore"]
 
 
-def unknown(v: "Unknown") -> int:  # type: ignore  # noqa
+def unannotated(x) -> int:  # type: ignore  # noqa
     ...
 
 
-def unannotated(x) -> int:  # type: ignore  # noqa
+def unknown(v: "Unknown") -> int:  # type: ignore  # noqa
     ...
 
 
@@ -129,47 +129,42 @@ def unknown_and_unannotated(v: "Unknown", x) -> int:  # type: ignore  # noqa
 def test_injection_errors(in_func, on_unresolved, on_unannotated):
 
     ctx: ContextManager = nullcontext()
+    ctxb: ContextManager = nullcontext()
     expect_same_func_back = False
 
-    if "unknown" in in_func.__name__:  # required params with unknown annotations
+    UNANNOTATED_MSG = "Injecting dependencies .* with a required, unannotated param"
+
+    if "unknown" in in_func.__name__ and on_unresolved != "ignore":
+        # required params with unknown annotations
+        UNRESOLVED_MSG = "Could not resolve type hint for required parameter"
+
         if on_unresolved == "raise":
-            ctx = pytest.raises(
-                NameError,
-                match="Could not resolve type hint for required parameter",
-            )
+            ctx = pytest.raises(NameError, match=UNRESOLVED_MSG)
+        elif on_unresolved == "warn":
+            ctx = pytest.warns(UserWarning, match=UNRESOLVED_MSG)
+            if "unannotated" in in_func.__name__:
+                if on_unannotated == "raise":
+                    ctxb = pytest.raises(TypeError, match=UNANNOTATED_MSG)
+                elif on_unannotated == "return":
+                    expect_same_func_back = True
         else:
             expect_same_func_back = True
-            if on_unresolved == "warn":
-                ctx = pytest.warns(
-                    UserWarning,
-                    match="Could not resolve type hint for required parameter",
-                )
 
     elif "unannotated" in in_func.__name__:  # required params without annotations
         if on_unannotated == "raise":
-            ctx = pytest.raises(
-                TypeError,
-                match="Injecting dependencies .* with a required, unannotated param",
-            )
+            ctx = pytest.raises(TypeError, match=UNANNOTATED_MSG)
         elif on_unannotated == "warn":
-            ctx = pytest.warns(
-                UserWarning,
-                match="Injecting dependencies .* with a required, unannotated param",
-            )
+            ctx = pytest.warns(UserWarning, match=UNANNOTATED_MSG)
         elif on_unannotated == "return":
             expect_same_func_back = True
 
-    with ctx:
+    with ctx, ctxb:
         out_func = inject(
             in_func,
             on_unannotated_required_args=on_unannotated,
             on_unresolved_required_args=on_unresolved,
         )
-
-        if expect_same_func_back:
-            assert out_func is in_func
-        else:
-            assert out_func is not in_func
+        assert (out_func is in_func) is expect_same_func_back
 
 
 def test_processors_not_passed_none(test_store: Store):
@@ -257,3 +252,15 @@ def test_wrapped_functions():
     foo = Foo()
     with register(providers={Foo: lambda: foo}):
         assert injected() == foo
+
+
+def test_partial_annotations():
+    def func(foo: Foo, bar: "Bar"):  # noqa
+        return foo, bar
+
+    with pytest.warns(UserWarning):
+        injected = inject(func)
+
+    foo = Foo()
+    with register(providers={Foo: lambda: foo}):
+        assert injected(bar=2) == (foo, 2)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -261,6 +261,8 @@ def test_partial_annotations():
     with pytest.warns(UserWarning):
         injected = inject(func)
 
+    injected = inject(func, on_unresolved_required_args="ignore")
+
     foo = Foo()
     with register(providers={Foo: lambda: foo}):
-        assert injected(bar=2) == (foo, 2)
+        assert injected(bar=2) == (foo, 2)  # type: ignore


### PR DESCRIPTION
This allows the following test case to pass:

```python
def func(foo: Foo, bar: "Bar"):  # noqa
    return foo, bar

injected = inject(func, on_unresolved_required_args="ignore")

foo = Foo()
with register(providers={Foo: lambda: foo}):
    assert injected(bar=2) == (foo, 2)

```